### PR TITLE
Fix Null Reference Error

### DIFF
--- a/Quantumhangar/HangarChecks/PlayerChecks.cs
+++ b/Quantumhangar/HangarChecks/PlayerChecks.cs
@@ -379,14 +379,15 @@ namespace QuantumHangar.HangarChecks
         }
 
         public void DetailedInfo(string input)
-        {
+        {           
+            PlayersHanger = new PlayerHangar(SteamID, Chat);
+
             if (!PlayersHanger.ParseInput(input, out int ID))
             {
                 Chat.Respond($"Grid {input} could not be found!");
                 return;
             }
 
-            PlayersHanger = new PlayerHangar(SteamID, Chat);
             PlayersHanger.DetailedReport(ID);
         }
 


### PR DESCRIPTION
Fixes the Null Reference Error with the !h info command.

I have tested this and it is now working again for both ID and Grid Name