### PR TITLE
Prevent duping between save and restart

### DIFF
--- a/HangarMarket/HangarStoreMod.csproj
+++ b/HangarMarket/HangarStoreMod.csproj
@@ -47,52 +47,52 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="ProtoBuf.Net.Core">
-      <HintPath>..\..\..\4 Torch Server\DedicatedServer64\ProtoBuf.Net.Core.dll</HintPath>
+      <HintPath>..\Quantumhangar\GameBinaries\ProtoBuf.Net.Core.dll</HintPath>
     </Reference>
     <Reference Include="Sandbox.Common">
-      <HintPath>..\..\..\4 Torch Server\DedicatedServer64\Sandbox.Common.dll</HintPath>
+      <HintPath>..\Quantumhangar\GameBinaries\Sandbox.Common.dll</HintPath>
     </Reference>
     <Reference Include="Sandbox.Game">
-      <HintPath>..\..\..\4 Torch Server\DedicatedServer64\Sandbox.Game.dll</HintPath>
+      <HintPath>..\Quantumhangar\GameBinaries\Sandbox.Game.dll</HintPath>
     </Reference>
     <Reference Include="Sandbox.Graphics">
-      <HintPath>..\..\..\4 Torch Server\DedicatedServer64\Sandbox.Graphics.dll</HintPath>
+      <HintPath>..\Quantumhangar\GameBinaries\Sandbox.Graphics.dll</HintPath>
     </Reference>
     <Reference Include="SpaceEngineers.ObjectBuilders">
-      <HintPath>..\..\..\4 Torch Server\DedicatedServer64\SpaceEngineers.ObjectBuilders.dll</HintPath>
+      <HintPath>..\Quantumhangar\GameBinaries\SpaceEngineers.ObjectBuilders.dll</HintPath>
     </Reference>
     <Reference Include="VRage">
-      <HintPath>..\..\..\4 Torch Server\DedicatedServer64\VRage.dll</HintPath>
+      <HintPath>..\Quantumhangar\GameBinaries\VRage.dll</HintPath>
     </Reference>
     <Reference Include="VRage.Game">
-      <HintPath>..\..\..\4 Torch Server\DedicatedServer64\VRage.Game.dll</HintPath>
+      <HintPath>..\Quantumhangar\GameBinaries\VRage.Game.dll</HintPath>
     </Reference>
     <Reference Include="VRage.Input">
-      <HintPath>..\..\..\4 Torch Server\DedicatedServer64\VRage.Input.dll</HintPath>
+      <HintPath>..\Quantumhangar\GameBinaries\VRage.Input.dll</HintPath>
     </Reference>
     <Reference Include="VRage.Library">
-      <HintPath>..\..\..\4 Torch Server\DedicatedServer64\VRage.Library.dll</HintPath>
+      <HintPath>..\Quantumhangar\GameBinaries\VRage.Library.dll</HintPath>
     </Reference>
     <Reference Include="VRage.Math">
-      <HintPath>..\..\..\4 Torch Server\DedicatedServer64\VRage.Math.dll</HintPath>
+      <HintPath>..\Quantumhangar\GameBinaries\VRage.Math.dll</HintPath>
     </Reference>
     <Reference Include="VRage.NativeWrapper">
-      <HintPath>..\..\..\4 Torch Server\DedicatedServer64\VRage.NativeWrapper.dll</HintPath>
+      <HintPath>..\Quantumhangar\GameBinaries\VRage.NativeWrapper.dll</HintPath>
     </Reference>
     <Reference Include="VRage.Network">
-      <HintPath>..\..\..\4 Torch Server\DedicatedServer64\VRage.Network.dll</HintPath>
+      <HintPath>..\Quantumhangar\GameBinaries\VRage.Network.dll</HintPath>
     </Reference>
     <Reference Include="VRage.Render">
-      <HintPath>..\..\..\4 Torch Server\DedicatedServer64\VRage.Render.dll</HintPath>
+      <HintPath>..\Quantumhangar\GameBinaries\VRage.Render.dll</HintPath>
     </Reference>
     <Reference Include="VRage.Render11">
-      <HintPath>..\..\..\4 Torch Server\DedicatedServer64\VRage.Render11.dll</HintPath>
+      <HintPath>..\Quantumhangar\GameBinaries\VRage.Render11.dll</HintPath>
     </Reference>
     <Reference Include="VRage.Scripting">
-      <HintPath>..\..\..\4 Torch Server\DedicatedServer64\VRage.Scripting.dll</HintPath>
+      <HintPath>..\Quantumhangar\GameBinaries\VRage.Scripting.dll</HintPath>
     </Reference>
     <Reference Include="VRage.UserInterface">
-      <HintPath>..\..\..\4 Torch Server\DedicatedServer64\VRage.UserInterface.dll</HintPath>
+      <HintPath>..\Quantumhangar\GameBinaries\VRage.UserInterface.dll</HintPath>
     </Reference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/Quantumhangar/Configs/Settings.cs
+++ b/Quantumhangar/Configs/Settings.cs
@@ -225,5 +225,13 @@ namespace QuantumHangar
 
         private bool _allowLoadNearEnemy;
         public bool AllowLoadNearEnemy { get => _allowLoadNearEnemy; set => SetValue(ref _allowLoadNearEnemy, value); }
+
+        private bool _disableTempUseAfterServerSave;
+        public bool DisableTempUseAfterServerSave { get => _disableTempUseAfterServerSave; set => SetValue(ref _disableTempUseAfterServerSave, value); }
+
+        private int _minsToDisableTempUseAfterSave = 2;
+        public int MinsToDisableTempUseAfterSave { get => _minsToDisableTempUseAfterSave; set => SetValue(ref _minsToDisableTempUseAfterSave, value); }
+
+
     }
 }

--- a/Quantumhangar/Hangar.cs
+++ b/Quantumhangar/Hangar.cs
@@ -8,7 +8,9 @@ using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Timers;
 using System.Windows.Controls;
+using Sandbox.ModAPI;
 using Torch;
 using Torch.API;
 using Torch.API.Managers;
@@ -33,8 +35,8 @@ namespace QuantumHangar
 
         public TorchSessionManager TorchSession { get; private set; }
         public static bool ServerRunning { get; private set; }
-        private static System.Timers.Timer SaveDelayTimer;
-        public static bool DelayFromSaveActive;
+        private static readonly Timer SaveDelayTimer = new Timer();
+        public static bool DelayFromSaveActive = false;
 
         public static string MainPlayerDirectory { get; private set; }
         public static string MainFactionDirectory { get; private set; }
@@ -155,12 +157,14 @@ namespace QuantumHangar
 
         private void SaveDelayTimer_Elapsed(object sender, System.Timers.ElapsedEventArgs e)
         {
+            Log.Warn("Hangar Save Delay Finished");
             DelayFromSaveActive = false;
             SaveDelayTimer?.Stop();
         }
 
         private void Static_OnSavingCheckpoint(VRage.Game.MyObjectBuilder_Checkpoint obj)
         {
+            Log.Warn("Hangar Save Delay Started");
             DelayFromSaveActive = true;
             SaveDelayTimer.Interval = TimeSpan.FromMinutes(Config.MinsToDisableTempUseAfterSave).TotalMilliseconds;
             SaveDelayTimer.Start();

--- a/Quantumhangar/HangarChecks/Player/PlayerChecks.cs
+++ b/Quantumhangar/HangarChecks/Player/PlayerChecks.cs
@@ -74,13 +74,16 @@ namespace QuantumHangar.HangarChecks
 
             if (Hangar.DelayFromSaveActive)
             {
-                if (Config.MinsToDisableTempUseAfterSave < 2)
-                    _chat?.Respond($"Server is saving, paused, or restarting, please wait {Config.MinsToDisableTempUseAfterSave} minute and try again.");
+                if (Config.DisableTempUseAfterServerSave)
+                {
+                    if (Config.MinsToDisableTempUseAfterSave < 2)
+                        _chat?.Respond($"Server is saving, paused, or restarting, please wait {Config.MinsToDisableTempUseAfterSave} minute and try again.");
 
-                if (Config.MinsToDisableTempUseAfterSave >= 2)
-                    _chat?.Respond($"Server is saving, paused, or restarting, please wait {Config.MinsToDisableTempUseAfterSave} minutes and try again.");
+                    if (Config.MinsToDisableTempUseAfterSave >= 2)
+                        _chat?.Respond($"Server is saving, paused, or restarting, please wait {Config.MinsToDisableTempUseAfterSave} minutes and try again.");
 
-                return false;
+                    return false;
+                }
             }
 
 

--- a/Quantumhangar/HangarChecks/Player/PlayerChecks.cs
+++ b/Quantumhangar/HangarChecks/Player/PlayerChecks.cs
@@ -72,6 +72,12 @@ namespace QuantumHangar.HangarChecks
                 return false;
             }
 
+            if (Hangar.DelayFromSaveActive)
+            {
+                _chat?.Respond("Server is saving, paused, or restarting, please wait a minute or two and try again.");
+                return false;
+            }
+
 
             if (!CheckZoneRestrictions(isSaving))
             {

--- a/Quantumhangar/HangarChecks/Player/PlayerChecks.cs
+++ b/Quantumhangar/HangarChecks/Player/PlayerChecks.cs
@@ -74,7 +74,12 @@ namespace QuantumHangar.HangarChecks
 
             if (Hangar.DelayFromSaveActive)
             {
-                _chat?.Respond("Server is saving, paused, or restarting, please wait a minute or two and try again.");
+                if (Config.MinsToDisableTempUseAfterSave < 2)
+                    _chat?.Respond($"Server is saving, paused, or restarting, please wait {Config.MinsToDisableTempUseAfterSave} minute and try again.");
+
+                if (Config.MinsToDisableTempUseAfterSave >= 2)
+                    _chat?.Respond($"Server is saving, paused, or restarting, please wait {Config.MinsToDisableTempUseAfterSave} minutes and try again.");
+
                 return false;
             }
 

--- a/Quantumhangar/UI/UserControlInterface.xaml
+++ b/Quantumhangar/UI/UserControlInterface.xaml
@@ -397,6 +397,34 @@
                         </Grid>
                     </GroupBox>
 
+                    <GroupBox >
+                        <GroupBox.Header>
+                            <TextBlock>
+                                        <Span FontWeight="Bold">Restart Settings</Span>
+                                        <Span>(Prevent grid duping between save and restart)</Span>
+                            </TextBlock>
+                        </GroupBox.Header>
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition/>
+                                <ColumnDefinition/>
+                                <ColumnDefinition/>
+                                <ColumnDefinition/>
+                            </Grid.ColumnDefinitions>
+                            <Grid.RowDefinitions>
+                                <RowDefinition/>
+                                <RowDefinition/>
+                                <RowDefinition/>
+                                <RowDefinition/>
+                                <RowDefinition/>
+                            </Grid.RowDefinitions>
+                            
+                            <CheckBox Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2" Content="Disable Saving/Loading after a system save." IsChecked="{Binding DisableTempUseAfterServerSave, Mode=TwoWay}"/>
+                            <TextBlock Grid.Row="1" Grid.Column="2" Text="How many mins?" HorizontalAlignment="Right"/>
+                            <TextBox Grid.Row="1" Grid.Column="3" Text="{Binding MinsToDisableTempUseAfterSave, Mode=TwoWay}" />
+                        </Grid>
+                    </GroupBox>
+
 
 
 

--- a/Quantumhangar/manifest.xml
+++ b/Quantumhangar/manifest.xml
@@ -3,5 +3,5 @@
 	<Name>Quantum Hangar</Name>
 	<Guid>24fc7724-0740-4a54-8bb3-1191fd3c8db4</Guid>
 	<Repository>Quantum Hangar</Repository>
-	<Version>v3.2.30</Version>
+	<Version>v3.2.31</Version>
 </PluginManifest>


### PR DESCRIPTION
Allows the server owner/admin to set a delay from when a save/checkpoint is created and when a player can save a grid to hangar.  This works beter than setting exact restart times because some hosted servers dont allow setting exact times but offer a window when the server may restart.