### PR TITLE
Autohangar changes and !hm reset 

### DIFF
--- a/Quantumhangar/Commands/HangarAdminCommands.cs
+++ b/Quantumhangar/Commands/HangarAdminCommands.cs
@@ -154,7 +154,14 @@ namespace QuantumHangar.Commands
 
         }
 
+        [Command("reset", "changes the flag to allow grid to be unhangared at players location")]
+        [Permission(MyPromoteLevel.Moderator)]
+        public async void Reset(string NameOrSteamID, int ID)
+        {
+            AdminChecks User = new AdminChecks(Context);
+            await HangarCommandSystem.RunAdminTaskAsync(() => User.SetForceSpawnNearPlayer(NameOrSteamID, ID));
 
+        }
     }
 
 
@@ -265,7 +272,14 @@ namespace QuantumHangar.Commands
             await HangarCommandSystem.RunAdminTaskAsync(() => AutoHangar.RunAutoHangar(true, true, true, true, true));
         }
 
-
+        [Command("reset", "changes the flag to allow grid to be unhangared at players location")]
+        [Permission(MyPromoteLevel.Moderator)]
+        public async void Reset(string NameOrSteamID, int ID)
+        {
+            AdminChecks User = new AdminChecks(Context); 
+            await HangarCommandSystem.RunAdminTaskAsync(() => User.SetForceSpawnNearPlayer(NameOrSteamID, ID));
+            
+        }
         /*
         [Command("exportgrid", "exportgrids to obj")]
         [Permission(MyPromoteLevel.Admin)]

--- a/Quantumhangar/HangarChecks/Player/PlayerChecks.cs
+++ b/Quantumhangar/HangarChecks/Player/PlayerChecks.cs
@@ -396,7 +396,7 @@ namespace QuantumHangar.HangarChecks
                 return;
 
             PluginDependencies.BackupGrid(grids.ToList(), _identityId);
-            var spawnPos = DetermineSpawnPosition(stamp.GridSavePosition, _playerPosition, out var keepOriginalPosition, loadNearPlayer || stamp.ForceSpawnNearPlayer);
+            var spawnPos = DetermineSpawnPosition(stamp.GridSavePosition, _playerPosition, out var keepOriginalPosition, stamp.ForceSpawnNearPlayer || loadNearPlayer);
 
             if (!CheckDistanceToLoadPoint(spawnPos))
                 return;
@@ -671,6 +671,13 @@ namespace QuantumHangar.HangarChecks
         private static Vector3D DetermineSpawnPosition(Vector3D gridPosition, Vector3D characterPosition,
             out bool keepOriginalPosition, bool playersSpawnNearPlayer = false)
         {
+
+            if (playersSpawnNearPlayer)
+            {
+                keepOriginalPosition = false;
+                return characterPosition;
+            }
+
             switch (Config.LoadType)
             {
                 //If the ship is loading from where it saved, we want to ignore aligning to gravity. (Needs to attempt to spawn in original position)
@@ -688,12 +695,6 @@ namespace QuantumHangar.HangarChecks
                 case LoadType.ForceLoadMearPlayer:
                     keepOriginalPosition = false;
                     return characterPosition;
-            }
-
-            if (playersSpawnNearPlayer)
-            {
-                keepOriginalPosition = false;
-                return characterPosition;
             }
             keepOriginalPosition = true;
             return gridPosition;

--- a/Quantumhangar/HangarChecks/Player/PlayerChecks.cs
+++ b/Quantumhangar/HangarChecks/Player/PlayerChecks.cs
@@ -396,8 +396,7 @@ namespace QuantumHangar.HangarChecks
                 return;
 
             PluginDependencies.BackupGrid(grids.ToList(), _identityId);
-            var spawnPos = DetermineSpawnPosition(stamp.GridSavePosition, _playerPosition, out var keepOriginalPosition,
-                loadNearPlayer);
+            var spawnPos = DetermineSpawnPosition(stamp.GridSavePosition, _playerPosition, out var keepOriginalPosition, loadNearPlayer || stamp.ForceSpawnNearPlayer);
 
             if (!CheckDistanceToLoadPoint(spawnPos))
                 return;

--- a/Quantumhangar/HangarChecks/Player/PlayerHangar.cs
+++ b/Quantumhangar/HangarChecks/Player/PlayerHangar.cs
@@ -108,6 +108,18 @@ namespace QuantumHangar.HangarChecks
 
             return true;
         }
+        public bool ForceSpawnNearPlayer(int ID)
+        {
+            string Message;
+            if (!this.SelectedPlayerFile.IsInputValid(ID, out Message))
+            {
+                this._chat.Respond(Message);
+                return false;
+            }
+            this.SelectedPlayerFile.Grids[ID - 1].ForceSpawnNearPlayer = true;
+            this.SelectedPlayerFile.SaveFile();
+            return true;
+        }
 
         public static bool TransferGrid(PlayerInfo to, GridStamp stamp)
         {
@@ -1038,7 +1050,7 @@ namespace QuantumHangar.HangarChecks
             {
                 result.GridName = FileSaver.CheckInvalidCharacters(result.GridName);
                 // Log.Warn("Running GridName Checks: {" + GridName + "} :" + Test);
-
+                result.GridName += $" +{result.NumberOfGrids-1} connected grids";
                 if (!AnyGridsMatch(result.GridName)) return;
                 //There is already a grid with that name!
                 var nameCheckDone = false;
@@ -1057,12 +1069,15 @@ namespace QuantumHangar.HangarChecks
                 }
 
                 //Main.Debug("Saving grid name: " + GridName);
+
                 result.GridName = result.GridName + "[" + a + "]";
             }
             catch (Exception e)
             {
                 Log.Warn(e);
             }
+
+         
         }
 
         public void ServerOfferPurchased(string name)

--- a/Quantumhangar/HangarChecks/Player/PlayerHangar.cs
+++ b/Quantumhangar/HangarChecks/Player/PlayerHangar.cs
@@ -1050,7 +1050,10 @@ namespace QuantumHangar.HangarChecks
             {
                 result.GridName = FileSaver.CheckInvalidCharacters(result.GridName);
                 // Log.Warn("Running GridName Checks: {" + GridName + "} :" + Test);
-                result.GridName += $" +{result.NumberOfGrids-1} connected grids";
+                if (result.NumberOfGrids > 1)
+                {
+                    result.GridName += $" +{result.NumberOfGrids - 1} connected grids";
+                }
                 if (!AnyGridsMatch(result.GridName)) return;
                 //There is already a grid with that name!
                 var nameCheckDone = false;


### PR DESCRIPTION
Autohangar - send grids to individual owners hangers 
Autohangar - Remove ineligible grids from the saving instead of skipping the group
Grid stamp - append +GridCount connected grids when multiple grids in stamp 

!hm reset - reset the ForceLoadNearPlayer flag to true 