### PR TITLE
hangar: checks: load should check load currency, not save currency

### DIFF
--- a/Quantumhangar/HangarChecks/Alliances/AllianceChecks.cs
+++ b/Quantumhangar/HangarChecks/Alliances/AllianceChecks.cs
@@ -334,7 +334,7 @@ namespace QuantumHangar.HangarChecks
         private bool RequireLoadCurrency(GridStamp grid)
         {
             //MyObjectBuilder_Definitions(MyParticlesManager)
-            if (!Config.RequireCurrency)
+            if (!Config.RequireLoadCurrency)
             {
                 return true;
             }

--- a/Quantumhangar/HangarChecks/Faction/FactionChecks.cs
+++ b/Quantumhangar/HangarChecks/Faction/FactionChecks.cs
@@ -314,7 +314,7 @@ namespace QuantumHangar.HangarChecks
         private bool RequireLoadCurrency(GridStamp grid)
         {
             //MyObjectBuilder_Definitions(MyParticlesManager)
-            if (!Config.RequireCurrency)
+            if (!Config.RequireLoadCurrency)
             {
                 return true;
             }

--- a/Quantumhangar/HangarChecks/Player/PlayerChecks.cs
+++ b/Quantumhangar/HangarChecks/Player/PlayerChecks.cs
@@ -260,7 +260,7 @@ namespace QuantumHangar.HangarChecks
         private bool RequireLoadCurrency(GridStamp grid)
         {
             //MyObjectBuilder_Definitions(MyParticlesManager)
-            if (!Config.RequireCurrency)
+            if (!Config.RequireLoadCurrency)
             {
                 return true;
             }


### PR DESCRIPTION
I noticed there's a config setting for save currency (`RequireCurrency`) and another for load currency (`RequireLoadCurrency`), but it's actually unused, and the load only checks the save currency setting (`RequireCurrency`). I think it should check (`RequireLoadCurrency`) instead.