### PR TITLE
Fix hangar corruption from same filename, +# connected for faction/alliance hangars

### DIFF
--- a/Quantumhangar/HangarChecks/Alliances/AllianceHanger.cs
+++ b/Quantumhangar/HangarChecks/Alliances/AllianceHanger.cs
@@ -1055,13 +1055,13 @@ namespace QuantumHangar.HangarChecks
             try
             {
                 result.GridName = FileSaver.CheckInvalidCharacters(result.GridName);
-				// Log.Warn("Running GridName Checks: {" + GridName + "} :" + Test);
-				if (result.NumberOfGrids > 1)
-				{
-					result.GridName += $" +{result.NumberOfGrids - 1} connected grids";
-				}
+                // Log.Warn("Running GridName Checks: {" + GridName + "} :" + Test);
+                if (result.NumberOfGrids > 1)
+                {
+                    result.GridName += $" +{result.NumberOfGrids - 1} connected grids";
+                }
 
-				if (!AnyGridsMatch(result.GridName)) return;
+                if (!AnyGridsMatch(result.GridName)) return;
                 //There is already a grid with that name!
                 var nameCheckDone = false;
                 var a = 1;

--- a/Quantumhangar/HangarChecks/Alliances/AllianceHanger.cs
+++ b/Quantumhangar/HangarChecks/Alliances/AllianceHanger.cs
@@ -979,12 +979,12 @@ namespace QuantumHangar.HangarChecks
 
         public bool AnyGridsMatch(string gridName)
         {
-            return Grids.Any(x => x.GridName.Equals(gridName, StringComparison.Ordinal));
+            return Grids.Any(x => x.GridName.Equals(gridName, StringComparison.OrdinalIgnoreCase));
         }
 
         public bool TryFindGridIndex(string gridName, int result)
         {
-            var foundIndex = (short?)Grids.FindIndex(x => x.GridName.Equals(gridName, StringComparison.Ordinal));
+            var foundIndex = (short?)Grids.FindIndex(x => x.GridName.Equals(gridName, StringComparison.OrdinalIgnoreCase));
             return foundIndex != -1;
         }
 
@@ -1055,9 +1055,13 @@ namespace QuantumHangar.HangarChecks
             try
             {
                 result.GridName = FileSaver.CheckInvalidCharacters(result.GridName);
-                // Log.Warn("Running GridName Checks: {" + GridName + "} :" + Test);
+				// Log.Warn("Running GridName Checks: {" + GridName + "} :" + Test);
+				if (result.NumberOfGrids > 1)
+				{
+					result.GridName += $" +{result.NumberOfGrids - 1} connected grids";
+				}
 
-                if (!AnyGridsMatch(result.GridName)) return;
+				if (!AnyGridsMatch(result.GridName)) return;
                 //There is already a grid with that name!
                 var nameCheckDone = false;
                 var a = 1;

--- a/Quantumhangar/HangarChecks/Faction/FactionHanger.cs
+++ b/Quantumhangar/HangarChecks/Faction/FactionHanger.cs
@@ -1036,12 +1036,12 @@ namespace QuantumHangar.HangarChecks
 
         public bool AnyGridsMatch(string gridName)
         {
-            return Grids.Any(x => x.GridName.Equals(gridName, StringComparison.Ordinal));
+            return Grids.Any(x => x.GridName.Equals(gridName, StringComparison.OrdinalIgnoreCase));
         }
 
         public bool TryFindGridIndex(string gridName, int result)
         {
-            var foundIndex = (short?)Grids.FindIndex(x => x.GridName.Equals(gridName, StringComparison.Ordinal));
+            var foundIndex = (short?)Grids.FindIndex(x => x.GridName.Equals(gridName, StringComparison.OrdinalIgnoreCase));
             return foundIndex != -1;
         }
 
@@ -1113,6 +1113,10 @@ namespace QuantumHangar.HangarChecks
             {
                 result.GridName = FileSaver.CheckInvalidCharacters(result.GridName);
                 // Log.Warn("Running GridName Checks: {" + GridName + "} :" + Test);
+                if (result.NumberOfGrids > 1)
+                {
+                    result.GridName += $" +{result.NumberOfGrids - 1} connected grids";
+                }
 
                 if (!AnyGridsMatch(result.GridName)) return;
                 //There is already a grid with that name!

--- a/Quantumhangar/HangarChecks/Player/PlayerHangar.cs
+++ b/Quantumhangar/HangarChecks/Player/PlayerHangar.cs
@@ -961,12 +961,12 @@ namespace QuantumHangar.HangarChecks
 
         public bool AnyGridsMatch(string gridName)
         {
-            return Grids.Any(x => x.GridName.Equals(gridName, StringComparison.Ordinal));
+            return Grids.Any(x => x.GridName.Equals(gridName, StringComparison.OrdinalIgnoreCase));
         }
 
         public bool TryFindGridIndex(string gridName, int result)
         {
-            var foundIndex = (short?)Grids.FindIndex(x => x.GridName.Equals(gridName, StringComparison.Ordinal));
+            var foundIndex = (short?)Grids.FindIndex(x => x.GridName.Equals(gridName, StringComparison.OrdinalIgnoreCase));
             return foundIndex != -1;
         }
 


### PR DESCRIPTION
Modifying check to be case insensitive to prevent file corruption
Adding +# connected option for faction hangar and alliance hangar